### PR TITLE
Fix : Ajout de tests unitaires pour les services

### DIFF
--- a/blog-api/src/main/java/com/esiea/blogAPI/controller/ArticleController.java
+++ b/blog-api/src/main/java/com/esiea/blogAPI/controller/ArticleController.java
@@ -31,7 +31,7 @@ public class ArticleController {
 	
 	@GetMapping("")
 	public Iterable <Article> getArticles(){
-		return articleService.getArticle();
+		return articleService.getArticles();
 	}
 	@GetMapping("{id}")
 	public ResponseEntity<Article> getArticle(@PathVariable("id") long id)

--- a/blog-api/src/main/java/com/esiea/blogAPI/service/ArticleService.java
+++ b/blog-api/src/main/java/com/esiea/blogAPI/service/ArticleService.java
@@ -29,11 +29,11 @@ public class ArticleService {
 	private CategoryService categoryService;
 	
 
-	public Iterable<Article> getArticle(){
+	public Iterable<Article> getArticles(){
 		return articleRepository.findAll();
 	}
 	
-	public Article getArticle(long id) throws NotFoundException {
+	public Article getArticle(Long id) throws NotFoundException {
 		Optional<Article> result = articleRepository.findById(id);
 		if(result.isPresent())
 			return result.get();
@@ -75,7 +75,7 @@ public class ArticleService {
 	 * @throws CategoryNotFoundException Si un ID est défini, mais que le nom de la catégorie ne correspond pas et n'est pas nul, lève cette exception
 	 */
 	private void setAuthorAndCategory(Article RepoArticle, Article newArticle, boolean force) throws NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
-		if(force || newArticle.getAuthor() != null && !RepoArticle.getAuthor().equalsOrNull(newArticle.getAuthor()))
+		if(force || newArticle.getAuthor() != null && (!RepoArticle.getAuthor().equalsOrNull(newArticle.getAuthor())))
 		{
 			try {
 				Author author = this.authorService.CreateAuthorIfNotExist(newArticle.getAuthor());
@@ -84,7 +84,7 @@ public class ArticleService {
 				throw new AuthorNotFoundException();
 			}
 		}
-		if(force || newArticle.getCategory() != null && !RepoArticle.getCategory().equalsOrNull(newArticle.getCategory()))
+		if(force || newArticle.getCategory() != null && (!RepoArticle.getCategory().equalsOrNull(newArticle.getCategory())))
 		{
 			try {
 				Category category = this.categoryService.CreateCategoryIfNotExist(newArticle.getCategory());
@@ -109,15 +109,14 @@ public class ArticleService {
 	 */
 	public Article patch(Article newArticle) throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
 		Article currentArticle = this.getArticle(newArticle.getId());
-		if(newArticle.getTitle() != null && newArticle.getTitle() != currentArticle.getTitle())
+		if(newArticle.getTitle() != null && !newArticle.getTitle().equals(currentArticle.getTitle()))
 			currentArticle.setTitle(newArticle.getTitle());
-		if(newArticle.getContent() != null && newArticle.getContent() != currentArticle.getContent())
+		if(newArticle.getContent() != null && !newArticle.getContent().equals(currentArticle.getContent()))
 			currentArticle.setContent(newArticle.getContent());
 		if(newArticle.getPublicationDate() != null && !newArticle.getPublicationDate().equals(currentArticle.getPublicationDate()))
 			currentArticle.setPublicationDate(newArticle.getPublicationDate());
 		setAuthorAndCategory(currentArticle, newArticle, false);
-		articleRepository.save(currentArticle);
-		return currentArticle;
+		return articleRepository.save(currentArticle);
 	}
 
 	public void delete(long id) throws NotFoundException {

--- a/blog-api/src/main/java/com/esiea/blogAPI/service/ArticleService.java
+++ b/blog-api/src/main/java/com/esiea/blogAPI/service/ArticleService.java
@@ -104,7 +104,7 @@ public class ArticleService {
 	 * @return L'article patché
 	 * @throws NotFoundException Si l'article n'éxiste pas
 	 * @throws NotAllowedException Echec de la sauvegarde dans la base de données
-	 * @throws AuthorNotFoundExceptionSi un ID est défini, mais que le nom/prenom de l'auteur ne correspond pas et ne sont pas nul, lève cette exception
+	 * @throws AuthorNotFoundException un ID est défini, mais que le nom/prenom de l'auteur ne correspond pas et ne sont pas nul, lève cette exception
 	 * @throws CategoryNotFoundException Si un ID est défini, mais que le nom de la catégorie ne correspond pas et n'est pas nul, lève cette exception
 	 */
 	public Article patch(Article newArticle) throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {

--- a/blog-api/src/main/java/com/esiea/blogAPI/service/AuthorService.java
+++ b/blog-api/src/main/java/com/esiea/blogAPI/service/AuthorService.java
@@ -42,10 +42,11 @@ public class AuthorService {
 		Author currentAuthor;
 		if(author.getId() == null)
 			currentAuthor = this.save(author);
-		else
+		else {
 			currentAuthor = this.getAuthor(author.getId());
-			if(!currentAuthor.equalsOrNull(author))
+			if (!currentAuthor.equalsOrNull(author))
 				throw new NotFoundException();
+		}
 		return currentAuthor;
 	}
 
@@ -56,15 +57,15 @@ public class AuthorService {
 	
 
 	public Author patch(Author newAuthor) throws NotFoundException, CantModifyItem {
-		Author currendAuthor = this.getAuthor(newAuthor.getId());
-		if(newAuthor.getFirstName() != null && newAuthor.getFirstName() != currendAuthor.getFirstName())
-			currendAuthor.setFirstName(newAuthor.getFirstName());
-		if(newAuthor.getLastName() != null && !newAuthor.getLastName().equals(currendAuthor.getLastName()))
-			currendAuthor.setLastName(newAuthor.getLastName());
-		if(newAuthor.getArticles() != null && !newAuthor.getArticles().equals(currendAuthor.getArticles()))
+		Author currentAuthor = this.getAuthor(newAuthor.getId());
+		if(newAuthor.getFirstName() != null && newAuthor.getFirstName() != currentAuthor.getFirstName())
+			currentAuthor.setFirstName(newAuthor.getFirstName());
+		if(newAuthor.getLastName() != null && !newAuthor.getLastName().equals(currentAuthor.getLastName()))
+			currentAuthor.setLastName(newAuthor.getLastName());
+		if(newAuthor.getArticles() != null && !newAuthor.getArticles().equals(currentAuthor.getArticles()))
 			throw new CantModifyItem();
-		authorRepository.save(currendAuthor);
-		return currendAuthor;
+		authorRepository.save(currentAuthor);
+		return currentAuthor;
 	}
 
 	public void delete(long id) throws NotFoundException {

--- a/blog-api/src/main/java/com/esiea/blogAPI/service/CategoryService.java
+++ b/blog-api/src/main/java/com/esiea/blogAPI/service/CategoryService.java
@@ -17,7 +17,7 @@ import com.esiea.blogAPI.repository.CategoryRepository;
 public class CategoryService {
 	@Autowired
 	private CategoryRepository categoryRepository;
-	
+
 	public Iterable<Category> getCategories(){
 		return categoryRepository.findAll();
 	}
@@ -34,10 +34,11 @@ public class CategoryService {
 		Category currentCategory;
 		if(category.getId() == null)
 			currentCategory = this.save(category);
-		else
+		else {
 			currentCategory = this.getCategory(category.getId());
-			if(!currentCategory.equalsOrNull(category))
+			if (!currentCategory.equalsOrNull(category))
 				throw new NotFoundException();
+		}
 		return currentCategory;
 	}
 
@@ -47,20 +48,19 @@ public class CategoryService {
 		throw new NotAllowedException();
 	}
 
-	public Category replace(Category author) throws NotFoundException, NotAllowedException {
-		this.getCategory(author.getId());
-		return categoryRepository.save(author);
+	public Category replace(Category category) throws NotFoundException, NotAllowedException {
+		this.getCategory(category.getId());
+		return categoryRepository.save(category);
 	}
 	
 
 	public Category patch(Category newCategory) throws NotFoundException, CantModifyItem {
-		Category currendAuthor = this.getCategory(newCategory.getId());
-		if(newCategory.getCategoryName() != null && newCategory.getCategoryName() != currendAuthor.getCategoryName())
-			currendAuthor.setCategoryName(newCategory.getCategoryName());
-		if(newCategory.getArticles() != null && !newCategory.getArticles().equals(currendAuthor.getArticles()))
+		Category currentCategory = this.getCategory(newCategory.getId());
+		if(newCategory.getCategoryName() != null && !newCategory.getCategoryName().equals(currentCategory.getCategoryName()))
+			currentCategory.setCategoryName(newCategory.getCategoryName());
+		if(newCategory.getArticles() != null && !newCategory.getArticles().equals(currentCategory.getArticles()))
 			throw new CantModifyItem();
-		categoryRepository.save(currendAuthor);
-		return currendAuthor;
+		return categoryRepository.save(currentCategory);
 	}
 
 	public void delete(long id) throws NotFoundException {

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/ArticleServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/ArticleServiceTest.java
@@ -1,0 +1,506 @@
+package com.esiea.blogAPI.service;
+
+import com.esiea.blogAPI.exception.AuthorNotFoundException;
+import com.esiea.blogAPI.exception.CategoryNotFoundException;
+import com.esiea.blogAPI.exception.NotAllowedException;
+import com.esiea.blogAPI.exception.NotFoundException;
+import com.esiea.blogAPI.model.Article;
+import com.esiea.blogAPI.model.Author;
+import com.esiea.blogAPI.model.Category;
+import com.esiea.blogAPI.repository.ArticleRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+    @Mock
+    private Article article1 = mock(Article.class);
+    @Mock
+    private Article article2 = mock(Article.class);
+    @Mock
+    private Article article3 = mock(Article.class);
+
+    @Mock
+    private Author author1 = mock(Author.class);
+    @Mock
+    private Author author2 = mock(Author.class);
+    @Mock
+    private Author author3 = mock(Author.class);
+
+    @Mock
+    private Category category1 = mock(Category.class);
+    @Mock
+    private Category category2 = mock(Category.class);
+    @Mock
+    private Category category3 = mock(Category.class);
+
+    @Mock
+    private ArticleRepository articleRepository= mock(ArticleRepository.class);
+    @Mock
+    private CategoryService categoryService = mock(CategoryService.class);
+    @Mock
+    private AuthorService authorService = mock(AuthorService.class);
+    @InjectMocks
+    private ArticleService articleService;
+    private List<Article> articles1;
+    private List<Article> articles2;
+    @BeforeEach
+    void setUp(){
+        articles1 = new ArrayList<>();
+        articles1.add(article1);
+        articles1.add(article2);
+
+        articles2 = new ArrayList<>();
+        articles2.add(article2);
+        articles2.add(article3);
+    }
+
+    /**
+     * Test la récupération de l'ensemble des articles
+     */
+    @Test
+    void getArticles() {
+        when(articleRepository.findAll()).thenReturn(articles1);
+        when(article1.toString()).thenReturn("article1");
+        when(article2.toString()).thenReturn("article2");
+        Iterable<Article> result = articleService.getArticles();
+        Iterator<Article> resultIterator = result.iterator();
+        Assertions.assertEquals( "article1" ,resultIterator.next().toString());
+        Assertions.assertEquals( "article2" ,resultIterator.next().toString());
+    }
+
+    /**
+     * Test la récupération d'un article
+     * @throws NotFoundException
+     */
+    @Test
+    void getArticleGood() throws NotFoundException {
+        Long id = Long.valueOf(1);
+        when(articleRepository.findById(id)).thenReturn(Optional.of(article1));
+        when(article1.toString()).thenReturn("article1");
+        Article result = articleService.getArticle(id);
+        Assertions.assertEquals( "article1" ,result.toString());
+    }
+
+    /**
+     * Test la récupération d'un article quand l'article n'est pas trouvé dans la base de données
+     * @throws NotFoundException
+     */
+    @Test
+    void getArticleWrong() throws NotFoundException {
+        Long id = Long.valueOf(1);
+        when(articleRepository.findById(id)).thenReturn(Optional.empty());
+        Assertions.assertThrowsExactly(NotFoundException.class, () ->{articleService.getArticle(id);});
+    }
+
+    /**
+     * Test la sauvegarde sans erreurs
+     * @throws AuthorNotFoundException
+     * @throws NotAllowedException
+     * @throws CategoryNotFoundException
+     * @throws NotFoundException
+     */
+    @Test
+    void saveGood() throws AuthorNotFoundException, NotAllowedException, CategoryNotFoundException, NotFoundException {
+        when(article1.getId()).thenReturn(null);
+
+        when(article1.getAuthor()).thenReturn(author1);
+        //when(article2.getAuthor()).thenReturn(author1);
+        //when(author1.equalsOrNull(author1)).thenReturn(true);
+        when(article1.getCategory()).thenReturn(category1);
+        //when(article2.getCategory()).thenReturn(category1);
+        //when(category1.equalsOrNull(category1)).thenReturn(true);
+
+        when(authorService.CreateAuthorIfNotExist(author1)).thenReturn(author1);
+        when(categoryService.CreateCategoryIfNotExist(category1)).thenReturn(category1);
+
+        when(articleRepository.save(article1)).thenReturn(article3);
+        when(article3.toString()).thenReturn("article3");
+        Article result = articleService.save(article1);
+        Assertions.assertEquals("article3", result.toString());
+    }
+
+    /**
+     * Test la sauvegarde avec une erreur.
+     * L'article ne peut pas être ajouté à la base de donnée, s'il dispose déjà d'un ID
+     *
+     * @throws AuthorNotFoundException
+     * @throws NotAllowedException
+     * @throws CategoryNotFoundException
+     * @throws NotFoundException
+     */
+    @Test
+    void saveWrong() throws AuthorNotFoundException, NotAllowedException, CategoryNotFoundException, NotFoundException {
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotAllowedException.class,() ->{articleService.save(article1);});
+    }
+
+    /**
+     * Test la sauvegarde avec une erreur.
+     * L'auteur de l'article possède un ID, mais ne correspond pas à celui de la bdd
+     */
+    @Test
+    void saveAuthorNotFoundException() throws NotAllowedException, NotFoundException {
+        when(article1.getId()).thenReturn(null);
+
+        when(article1.getAuthor()).thenReturn(author1);
+
+        when(authorService.CreateAuthorIfNotExist(author1)).thenThrow(NotFoundException.class);
+
+        Assertions.assertThrowsExactly(AuthorNotFoundException.class, ()->{articleService.save(article1);});
+    }
+
+    /**
+     * Test la sauvegarde avec une erreur.
+     * La catégorie de l'article possède un ID, mais ne correspond pas à celui de la bdd
+     */
+    @Test
+    void saveCategoryNotFoundException() throws NotAllowedException, NotFoundException {
+        when(article1.getId()).thenReturn(null);
+        when(article1.getAuthor()).thenReturn(author1);
+        when(article1.getCategory()).thenReturn(category1);
+
+        when(authorService.CreateAuthorIfNotExist(author1)).thenReturn(author1);
+        when(categoryService.CreateCategoryIfNotExist(category1)).thenThrow(NotFoundException.class);
+
+        Assertions.assertThrowsExactly(CategoryNotFoundException.class, ()->{articleService.save(article1);});
+    }
+
+    /**
+     * Remplacement d'un article par un autre dans la bdd
+     * @throws NotFoundException
+     * @throws NotAllowedException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void replaceGood() throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Remplacement du titre
+        doNothing().when(article2).setTitle("newTitle");
+        when(article1.getTitle()).thenReturn("newTitle");
+
+        // Remplacement du contenu de l'article
+        doNothing().when(article2).setContent("newContent");
+        when(article1.getContent()).thenReturn("newContent");
+
+        // Remplacement de la date
+        doNothing().when(article2).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        when(article1.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+
+        // Récupération de l'auteur et de la categorie du nouvel article
+        when(article1.getAuthor()).thenReturn(author1);
+        when(article1.getCategory()).thenReturn(category1);
+
+        // Création ou récupération de l'auteur et de la catégorie dans la BDD
+        when(authorService.CreateAuthorIfNotExist(author1)).thenReturn(author1);
+        when(categoryService.CreateCategoryIfNotExist(category1)).thenReturn(category1);
+
+        // Remplacement de l'article
+        when(articleRepository.save(article2)).thenReturn(article3);
+        when(article3.toString()).thenReturn("article3");
+
+        // Test du remplacement
+        Article result = articleService.replace(article1);
+        Assertions.assertEquals("article3", result.toString());
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(1)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(1)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(1)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(1)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(1)).setCategory(category1);
+    }
+
+    /**
+     * Remplacement d'un article par un autre avec une erreur.
+     * L'article ne dispose pas d'ID
+     * @throws NotFoundException
+     * @throws NotAllowedException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void replaceWithoutId() throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(null);
+        when(articleRepository.findById(null)).thenReturn(Optional.empty());
+
+        // Test de l'erreur généré
+        Assertions.assertThrowsExactly(NotFoundException.class,()->{articleService.replace(article1);});
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(0)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(0)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(0)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(0)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(0)).setCategory(category1);
+    }
+
+    /**
+     * Remplacement d'un article avec erreur.
+     * L'auteur n'est pas trouvé dans la BDD
+     * @throws NotFoundException
+     * @throws NotAllowedException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void replaceWithBadAuthor() throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Remplacement du titre
+        doNothing().when(article2).setTitle("newTitle");
+        when(article1.getTitle()).thenReturn("newTitle");
+
+        // Remplacement du contenu de l'article
+        doNothing().when(article2).setContent("newContent");
+        when(article1.getContent()).thenReturn("newContent");
+
+        // Remplacement de la date
+        doNothing().when(article2).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        when(article1.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+
+        // Récupération de l'auteur du nouvel article
+        when(article1.getAuthor()).thenReturn(author1);
+
+        // Création ou récupération de l'auteur dans la BDD avec une erreur
+        when(authorService.CreateAuthorIfNotExist(author1)).thenThrow(NotFoundException.class);
+
+        // Test du remplacement
+        Assertions.assertThrowsExactly(AuthorNotFoundException.class, ()->{articleService.replace(article1);});
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(1)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(1)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(1)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(0)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(0)).setCategory(category1);
+    }
+
+    /**
+     * Remplacement d'un article avec erreur.
+     * La catégorie n'est pas trouvé dans la BDD
+     * @throws NotFoundException
+     * @throws NotAllowedException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void replaceWithBadCategory() throws NotFoundException, NotAllowedException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Remplacement du titre
+        when(article1.getTitle()).thenReturn("newTitle");
+
+        // Remplacement du contenu de l'article
+        when(article1.getContent()).thenReturn("newContent");
+
+        // Remplacement de la date
+        when(article1.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+
+        // Récupération de l'auteur et de la categorie du nouvel article
+        when(article1.getAuthor()).thenReturn(author1);
+        when(article1.getCategory()).thenReturn(category1);
+
+        // Création ou récupération de l'auteur et de la catégorie dans la BDD avec une erreur
+        when(authorService.CreateAuthorIfNotExist(author1)).thenReturn(author1);
+        when(categoryService.CreateCategoryIfNotExist(category1)).thenThrow(NotFoundException.class);
+
+        // Test du remplacement
+        Assertions.assertThrowsExactly(CategoryNotFoundException.class, ()->{articleService.replace(article1);});
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(1)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(1)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(1)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(1)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(0)).setCategory(category1);
+    }
+
+    /**
+     * Met à jour l'ensemble des attributs d'un article
+     * @throws NotAllowedException
+     * @throws NotFoundException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void patchAll() throws NotAllowedException, NotFoundException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Remplacement du titre
+        when(article1.getTitle()).thenReturn("newTitle");
+        when(article2.getTitle()).thenReturn("oldTitle");
+
+        // Remplacement du contenu de l'article
+        when(article1.getContent()).thenReturn("newContent");
+        when(article2.getContent()).thenReturn("oldContent");
+
+        // Remplacement de la date
+        when(article1.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+        when(article2.getPublicationDate()).thenReturn(Timestamp.valueOf("2021-02-02 00:00:00"));
+
+        // Récupération de l'auteur du nouvel article
+        when(article1.getAuthor()).thenReturn(author1);
+        when(article2.getAuthor()).thenReturn(author2);
+        when(author2.equalsOrNull(author1)).thenReturn(false);
+
+        when(authorService.CreateAuthorIfNotExist(author1)).thenReturn(author1);
+
+        // Récupération de la categorie du nouvel article
+        when(article1.getCategory()).thenReturn(category1);
+        when(article2.getCategory()).thenReturn(category2);
+        when(category2.equalsOrNull(category1)).thenReturn(false);
+
+        when(categoryService.CreateCategoryIfNotExist(category1)).thenReturn(category1);
+
+        // Mise à jour de l'article
+        when(articleRepository.save(article2)).thenReturn(article3);
+        when(article3.toString()).thenReturn("article3");
+
+        // Test de la mise à jour
+        Article result = articleService.patch(article1);
+        Assertions.assertEquals("article3", result.toString());
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(1)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(1)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(1)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(1)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(1)).setCategory(category1);
+    }
+
+    /**
+     * Ne met à jour aucun attribut puisque les attributs du nouvel article sont identiques
+     * @throws NotAllowedException
+     * @throws NotFoundException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void patchNoneBySame() throws NotAllowedException, NotFoundException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Pas de remplacement du titre
+        when(article1.getTitle()).thenReturn("newTitle");
+        when(article2.getTitle()).thenReturn("newTitle");
+
+        // Pas de remplacement du contenu de l'article
+        when(article1.getContent()).thenReturn("newContent");
+        when(article2.getContent()).thenReturn("newContent");
+
+        // Pas de remplacement de la date
+        when(article1.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+        when(article2.getPublicationDate()).thenReturn(Timestamp.valueOf("2022-02-02 00:00:00"));
+
+        // Récupération de l'auteur du nouvel article
+        when(article1.getAuthor()).thenReturn(author1);
+        when(article2.getAuthor()).thenReturn(author1);
+        when(author1.equalsOrNull(author1)).thenReturn(true);
+
+        // Récupération de la categorie du nouvel article
+        when(article1.getCategory()).thenReturn(category1);
+        when(article2.getCategory()).thenReturn(category1);
+        when(category1.equalsOrNull(category1)).thenReturn(true);
+
+        // Mise à jour de l'article
+        when(articleRepository.save(article2)).thenReturn(article3);
+        when(article3.toString()).thenReturn("article3");
+
+        // Test de la mise à jour
+        Article result = articleService.patch(article1);
+        Assertions.assertEquals("article3", result.toString());
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(0)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(0)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(0)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(0)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(0)).setCategory(category1);
+    }
+
+    /**
+     * Ne met à jour aucun attribut puisque les attributs du nouvel article sont null
+     * @throws NotAllowedException
+     * @throws NotFoundException
+     * @throws AuthorNotFoundException
+     * @throws CategoryNotFoundException
+     */
+    @Test
+    void patchNoneByNull() throws NotAllowedException, NotFoundException, AuthorNotFoundException, CategoryNotFoundException {
+        // Récupération de l'article déjà existant
+        when(article1.getId()).thenReturn(Long.valueOf(1));
+        when(articleRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(article2));
+
+        // Pas de remplacement du titre
+        when(article1.getTitle()).thenReturn(null);
+
+        // Pas de remplacement du contenu de l'article
+        when(article1.getContent()).thenReturn(null);
+
+        // Pas de remplacement de la date
+        when(article1.getPublicationDate()).thenReturn(null);
+
+        // Récupération de l'auteur du nouvel article
+        when(article1.getAuthor()).thenReturn(null);
+
+        // Récupération de la categorie du nouvel article
+        when(article1.getCategory()).thenReturn(null);
+
+        // Mise à jour de l'article
+        when(articleRepository.save(article2)).thenReturn(article3);
+        when(article3.toString()).thenReturn("article3");
+
+        // Test de la mise à jour
+        Article result = articleService.patch(article1);
+        Assertions.assertEquals("article3", result.toString());
+
+        // Vérification
+        Mockito.verify(article2, Mockito.times(0)).setTitle("newTitle");
+        Mockito.verify(article2, Mockito.times(0)).setContent("newContent");
+        Mockito.verify(article2, Mockito.times(0)).setPublicationDate(Timestamp.valueOf("2022-02-02 00:00:00"));
+        Mockito.verify(article2, Mockito.times(0)).setAuthor(author1);
+        Mockito.verify(article2, Mockito.times(0)).setCategory(category1);
+    }
+
+    @Test
+    void deleteGood() throws NotFoundException {
+        articleService.delete(Long.valueOf(1));
+        Mockito.verify(articleRepository, Mockito.times(1)).deleteById(Long.valueOf(1));
+    }
+
+    @Test
+    void deleteWrong() throws NotFoundException {
+        doThrow(EmptyResultDataAccessException.class).when(articleRepository).deleteById(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotFoundException.class, ()->{articleService.delete(Long.valueOf(1));});
+        Mockito.verify(articleRepository, Mockito.times(1)).deleteById(Long.valueOf(1));
+    }
+}

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/AuthorServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/AuthorServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.EmptyResultDataAccessException;
 
@@ -138,6 +139,7 @@ class AuthorServiceTest {
 
     @Test
     void replaceGood() throws NotAllowedException, NotFoundException {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
         when(authorRepository.save(author1)).thenReturn(author3);
@@ -146,118 +148,235 @@ class AuthorServiceTest {
         Assertions.assertEquals("author3", result.toString());
     }
 
+    /**
+     * Test du non-remplacement des attributs de l'auteur dans le cas où les valeurs seraient nulls
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchWithoutChangeByNull() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence de remplacement du prénom
         when(author1.getFirstName()).thenReturn(null);
-        //when(author2.getFirstName()).thenReturn("firstName");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn(null);
-        //when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(null);
-        //when(author2.getArticles()).thenReturn(authors1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // Test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(0)).setFirstName("");
+        Mockito.verify(author2, Mockito.times(0)).setLastName("");
     }
+
+    /**
+     * Test du non remplacement du prénom de l'auteur dans le cas où le prénom serait le même
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchWithoutChangeBySameFirstname() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence de remplacement du prénom
         when(author1.getFirstName()).thenReturn("firstName");
         when(author2.getFirstName()).thenReturn("firstName");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn(null);
-        //when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(null);
-        //when(author2.getArticles()).thenReturn(authors1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(0)).setFirstName("firstName");
+        Mockito.verify(author2, Mockito.times(0)).setLastName("");
     }
+
+    /**
+     * Test de la mise à jour dans le cas où le nom serait le même
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchWithoutChangeBySameLastname() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence de remplacement du prénom
         when(author1.getFirstName()).thenReturn(null);
-        //when(author2.getFirstName()).thenReturn("firstName");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn("lastname");
         when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(null);
-        //when(author2.getArticles()).thenReturn(authors1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(0)).setFirstName("");
+        Mockito.verify(author2, Mockito.times(0)).setLastName("lastname");
     }
 
+    /**
+     * test de la mise à jour dans le cas où la liste des articles serait la même
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchWithoutChangeBySameCategories() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence de remplacement du prénom
         when(author1.getFirstName()).thenReturn(null);
-        //when(author2.getFirstName()).thenReturn("firstName");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn(null);
-        //when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(articles1);
         when(author2.getArticles()).thenReturn(articles1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(0)).setFirstName("");
+        Mockito.verify(author2, Mockito.times(0)).setLastName("lastname");
+        Mockito.verify(author2, Mockito.times(0)).setArticles(articles1);
     }
 
+    /**
+     * test de la mise à jour du prénom
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchChangeFirstName() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Remplacement du prénom
         when(author1.getFirstName()).thenReturn("newFirstname");
         when(author2.getFirstName()).thenReturn("firstName");
         doNothing().when(author2).setFirstName("newFirstname");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn(null);
-        //when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(null);
-        //when(author2.getArticles()).thenReturn(authors1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(1)).setFirstName("newFirstname");
+        Mockito.verify(author2, Mockito.times(0)).setLastName("lastname");
     }
 
+    /**
+     * test de la mise à jour du nom
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchChangeLastname() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence du remplacement du prénom
         when(author1.getFirstName()).thenReturn(null);
-        //when(author2.getFirstName()).thenReturn("firstName");
+
+        // Remplacement du nom
         when(author1.getLastName()).thenReturn("newLastname");
         when(author2.getLastName()).thenReturn("lastname");
         doNothing().when(author2).setLastName("newLastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(null);
-        //when(author2.getArticles()).thenReturn(authors1);
+
+        // Sauvegarde de l'auteur
         when(authorRepository.save(author2)).thenReturn(author2);
         when(author2.toString()).thenReturn("author2");
 
+        // test de la mise à jour
         Author result = authorService.patch(author1);
         Assertions.assertEquals(author2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(author2, Mockito.times(0)).setFirstName("");
+        Mockito.verify(author2, Mockito.times(1)).setLastName("newLastname");
     }
 
+    /**
+     * Test de l'échec de la mise à jour de la liste des articles.
+     * La liaison doit être modifiée depuis l'article
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void patchChangeArticles() throws NotFoundException, CantModifyItem {
+        // Récupération de l'auteur
         when(author1.getId()).thenReturn(Long.valueOf(1));
         when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+
+        // Absence de remplacement du prénom
         when(author1.getFirstName()).thenReturn(null);
-        //when(author2.getFirstName()).thenReturn("firstName");
+
+        // Absence de remplacement du nom
         when(author1.getLastName()).thenReturn(null);
-        //when(author2.getLastName()).thenReturn("lastname");
+
+        // Absence de remplacement des articles
         when(author1.getArticles()).thenReturn(articles1);
         when(author2.getArticles()).thenReturn(articles2);
+
+        // test de la mise à jour
         Assertions.assertThrowsExactly(CantModifyItem.class, ()->{authorService.patch(author1);});
     }
 

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/AuthorServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/AuthorServiceTest.java
@@ -1,0 +1,275 @@
+package com.esiea.blogAPI.service;
+
+import com.esiea.blogAPI.exception.CantModifyItem;
+import com.esiea.blogAPI.exception.NotAllowedException;
+import com.esiea.blogAPI.exception.NotFoundException;
+import com.esiea.blogAPI.model.Article;
+import com.esiea.blogAPI.model.Author;
+import com.esiea.blogAPI.model.Category;
+import com.esiea.blogAPI.repository.AuthorRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorServiceTest {
+
+    @Mock
+    private Article article1 = mock(Article.class);
+    @Mock
+    private Article article2 = mock(Article.class);
+    @Mock
+    private Article article3 = mock(Article.class);
+    @Mock
+    private Author author1 = mock(Author.class);
+    @Mock
+    private Author author2 = mock(Author.class);
+    @Mock
+    private Author author3 = mock(Author.class);
+
+    @Mock
+    private AuthorRepository authorRepository = mock(AuthorRepository.class);
+
+    @InjectMocks
+    private AuthorService authorService;
+
+    private List<Article> articles1;
+    private List<Article> articles2;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        articles1 = new ArrayList<>();
+        articles1.add(article1);
+        articles1.add(article2);
+
+        articles2 = new ArrayList<>();
+        articles2.add(article2);
+        articles2.add(article3);
+    }
+
+    @Test
+    void getAuthors() {
+        List<Author> authors1 = new ArrayList<>();
+        authors1.add(author1);
+        authors1.add(author2);
+        when(authorRepository.findAll()).thenReturn(authors1);
+        when(author1.toString()).thenReturn("author1");
+        when(author2.toString()).thenReturn("author2");
+        Iterable<Author> result = authorService.getAuthors();
+        Iterator<Author> resultIterator = result.iterator();
+        Assertions.assertEquals( "author1" ,resultIterator.next().toString());
+        Assertions.assertEquals( "author2" ,resultIterator.next().toString());
+    }
+
+
+
+    @Test
+    void getAuthorGood() throws NotFoundException {
+        Long id = Long.valueOf(1);
+        List<Author> authors1 = new ArrayList<>();
+        when(authorRepository.findById(id)).thenReturn(Optional.of(author1));
+        when(author1.toString()).thenReturn("author1");
+        Author result = authorService.getAuthor(id);
+        Assertions.assertEquals( "author1" ,result.toString());
+    }
+
+    @Test
+    void getAuthorWrong() throws NotFoundException {
+        Long id = Long.valueOf(1);
+        when(authorRepository.findById(id)).thenReturn(Optional.empty());
+        Assertions.assertThrowsExactly(NotFoundException.class, () ->{authorService.getAuthor(id);});
+    }
+
+    @Test
+    void saveGood() throws NotAllowedException {
+        when(authorRepository.save(author1)).thenReturn(author2);
+        // Le save rajoute un id, donc la catégorie retournée n'est pas la même que celle en entrée
+        when(author2.toString()).thenReturn("author2");
+        when(author1.getId()).thenReturn(null);
+        Author result = authorService.save(author1);
+        Assertions.assertEquals("author2", result.toString());
+    }
+
+    @Test
+    void saveWrong(){
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotAllowedException.class, () ->{authorService.save(author1);});
+    }
+
+    @Test
+    void createAuthorIfNotExist() throws NotAllowedException, NotFoundException {
+        when(author1.getId()).thenReturn(null);
+        when(authorService.save(author1)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+        Author result = authorService.CreateAuthorIfNotExist(author1);
+        Assertions.assertEquals("author2", result.toString());
+    }
+
+    @Test
+    void createAuthorIfNotExistGetAuthor() throws NotAllowedException, NotFoundException {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author2.toString()).thenReturn("author2");
+        when(author2.equalsOrNull(author1)).thenReturn(true);
+        Author result = authorService.CreateAuthorIfNotExist(author1);
+        assertEquals("author2", result.toString());
+    }
+
+    @Test
+    void createAuthorIfNotExistGetCategoryWrong() throws NotAllowedException {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author2.equalsOrNull(author1)).thenReturn(false);
+        assertThrowsExactly(NotFoundException.class,()  ->{authorService.CreateAuthorIfNotExist(author1);});
+    }
+
+    @Test
+    void replaceGood() throws NotAllowedException, NotFoundException {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(authorRepository.save(author1)).thenReturn(author3);
+        when(author3.toString()).thenReturn("author3");
+        Author result = authorService.replace(author1);
+        Assertions.assertEquals("author3", result.toString());
+    }
+
+    @Test
+    void patchWithoutChangeByNull() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn(null);
+        //when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn(null);
+        //when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(null);
+        //when(author2.getArticles()).thenReturn(authors1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+    @Test
+    void patchWithoutChangeBySameFirstname() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn("firstName");
+        when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn(null);
+        //when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(null);
+        //when(author2.getArticles()).thenReturn(authors1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+    @Test
+    void patchWithoutChangeBySameLastname() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn(null);
+        //when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn("lastname");
+        when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(null);
+        //when(author2.getArticles()).thenReturn(authors1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+
+    @Test
+    void patchWithoutChangeBySameCategories() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn(null);
+        //when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn(null);
+        //when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(articles1);
+        when(author2.getArticles()).thenReturn(articles1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+
+    @Test
+    void patchChangeFirstName() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn("newFirstname");
+        when(author2.getFirstName()).thenReturn("firstName");
+        doNothing().when(author2).setFirstName("newFirstname");
+        when(author1.getLastName()).thenReturn(null);
+        //when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(null);
+        //when(author2.getArticles()).thenReturn(authors1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+
+    @Test
+    void patchChangeLastname() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn(null);
+        //when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn("newLastname");
+        when(author2.getLastName()).thenReturn("lastname");
+        doNothing().when(author2).setLastName("newLastname");
+        when(author1.getArticles()).thenReturn(null);
+        //when(author2.getArticles()).thenReturn(authors1);
+        when(authorRepository.save(author2)).thenReturn(author2);
+        when(author2.toString()).thenReturn("author2");
+
+        Author result = authorService.patch(author1);
+        Assertions.assertEquals(author2.toString(), result.toString());
+    }
+
+    @Test
+    void patchChangeArticles() throws NotFoundException, CantModifyItem {
+        when(author1.getId()).thenReturn(Long.valueOf(1));
+        when(authorRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(author2));
+        when(author1.getFirstName()).thenReturn(null);
+        //when(author2.getFirstName()).thenReturn("firstName");
+        when(author1.getLastName()).thenReturn(null);
+        //when(author2.getLastName()).thenReturn("lastname");
+        when(author1.getArticles()).thenReturn(articles1);
+        when(author2.getArticles()).thenReturn(articles2);
+        Assertions.assertThrowsExactly(CantModifyItem.class, ()->{authorService.patch(author1);});
+    }
+
+    @Test
+    void delete() throws NotFoundException {
+        doNothing().when(authorRepository).deleteById(Long.valueOf(1));
+        authorService.delete(Long.valueOf(1));
+    }
+
+    @Test
+    void deleteWrong(){
+        doThrow(EmptyResultDataAccessException.class).when(authorRepository).deleteById(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotFoundException.class, () -> {authorService.delete(Long.valueOf(1));});
+    }
+}

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
@@ -71,7 +71,6 @@ class CategoryServiceTest {
     @Test
     void getCategoryGood() throws NotFoundException {
         Long id = Long.valueOf(1);
-        List<Category> categories1 = new ArrayList<>();
         when(categoryRepository.findById(id)).thenReturn(Optional.of(category1));
         when(category1.toString()).thenReturn("category1");
         Category result = categoryService.getCategory(id);

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.EmptyResultDataAccessException;
 
@@ -143,76 +144,147 @@ class CategoryServiceTest {
         Assertions.assertThrowsExactly(NotFoundException.class, ()->{ categoryService.replace(category1);});
     }
 
+    /**
+     * Test du non-remplacement des attributs de la catégorie dans le cas où les valeurs seraient nulls
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void testPatchWithoutChangeByNull() throws NotFoundException, CantModifyItem {
+        // Récupération de la catégorie
         when(category1.getId()).thenReturn(Long.valueOf(1));
         when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+
+        // Absence de remplacement de la catégorie
         when(category1.getCategoryName()).thenReturn(null);
-        //when(category2.getCategoryName()).thenReturn("categoryName");
+
+        // Absence de remplacement des articles
         when(category1.getArticles()).thenReturn(null);
-        //when(category2.getArticles()).thenReturn(articles1);
+
+        // Sauvegarde de la catégorie
         when(categoryRepository.save(category2)).thenReturn(category2);
         when(category2.toString()).thenReturn("category2");
 
+        // Test de la mise à jour
         Category result = categoryService.patch(category1);
         Assertions.assertEquals(category2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(category2, Mockito.times(0)).setCategoryName("category2");
     }
 
+    /**
+     * Test de l'absence de la mise à jour du nom de la catégorie de l'article
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void testPatchWithoutChangeBySameCategoryName() throws NotFoundException, CantModifyItem {
+        // Récupération de la catégorie
         when(category1.getId()).thenReturn(Long.valueOf(1));
         when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+
+        // Absence de remplacement de la catégorie
         when(category1.getCategoryName()).thenReturn("categoryName");
         when(category2.getCategoryName()).thenReturn("categoryName");
+
+        // Absence de remplacement des articles
         when(category1.getArticles()).thenReturn(null);
-        //when(category2.getArticles()).thenReturn(articles1);
+
+        // Sauvegarde de la catégorie
         when(categoryRepository.save(category2)).thenReturn(category2);
         when(category2.toString()).thenReturn("category2");
 
+        // Test de la mise à jour
         Category result = categoryService.patch(category1);
         Assertions.assertEquals(category2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(category2, Mockito.times(0)).setCategoryName("category2");
     }
 
+    /**
+     * Test de l'absence de la mise à jour du nom de la catégorie de l'article
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void testPatchWithCategoryNameChange() throws NotFoundException, CantModifyItem {
+        // Récupération de la catégorie
         when(category1.getId()).thenReturn(Long.valueOf(1));
         when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+
+        // Remplacement de la catégorie
         when(category1.getCategoryName()).thenReturn("CategoryName1");
         when(category2.getCategoryName()).thenReturn("CategoryName2");
         doNothing().when(category2).setCategoryName("CategoryName1");
+
+        // Absence de remplacement des articles
         when(category1.getArticles()).thenReturn(null);
-        //when(category2.getArticles()).thenReturn(articles1);
+
+        // Sauvegarde de la catégorie
         when(categoryRepository.save(category2)).thenReturn(category2);
         when(category2.toString()).thenReturn("category2");
 
+        // Test de la mise à jour
         Category result = categoryService.patch(category1);
         Assertions.assertEquals(category2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(category2, Mockito.times(1)).setCategoryName("CategoryName1");
     }
 
+    /**
+     * Test du non-remplacement des articles dans le cas où les articles n'auraient pas changés
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void testPatchWithoutChangeBySameGetArticles() throws NotFoundException, CantModifyItem {
+        // Récupération de la catégorie
         when(category1.getId()).thenReturn(Long.valueOf(1));
         when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+
+        // Absence de remplacement de la catégorie
         when(category1.getCategoryName()).thenReturn(null);
-        //when(category2.getCategoryName()).thenReturn("categoryName");
+
+        // Absence de remplacement des articles
         when(category1.getArticles()).thenReturn(articles1);
         when(category2.getArticles()).thenReturn(articles1);
+
+        // Sauvegarde de la catégorie
         when(categoryRepository.save(category2)).thenReturn(category2);
         when(category2.toString()).thenReturn("category2");
 
+        // Test de la mise à jour
         Category result = categoryService.patch(category1);
         Assertions.assertEquals(category2.toString(), result.toString());
+
+        // Vérification
+        Mockito.verify(category2, Mockito.times(0)).setArticles(articles1);
+        Mockito.verify(category2, Mockito.times(0)).setCategoryName("category2");
     }
 
+    /**
+     * Test de l'échec de la mise à jour de la liste des articles.
+     * La liaison doit être modifiée depuis l'article
+     * @throws NotFoundException
+     * @throws CantModifyItem
+     */
     @Test
     void testPatchWithChangeGetArticles() throws NotFoundException, CantModifyItem {
+        // Récupération de la catégorie
         when(category1.getId()).thenReturn(Long.valueOf(1));
         when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+
+        // Absence de remplacement de la catégorie
         when(category1.getCategoryName()).thenReturn(null);
-        //when(category2.getCategoryName()).thenReturn("categoryName");
+
+        // Absence de remplacement des articles
         when(category1.getArticles()).thenReturn(articles1);
         when(category2.getArticles()).thenReturn(articles2);
 
+        // Test de la mise à jour
         Assertions.assertThrowsExactly(CantModifyItem.class, ()->{categoryService.patch(category1);}); ;
     }
 

--- a/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
+++ b/blog-api/src/test/java/com/esiea/blogAPI/service/CategoryServiceTest.java
@@ -1,0 +1,231 @@
+package com.esiea.blogAPI.service;
+
+import com.esiea.blogAPI.exception.CantModifyItem;
+import com.esiea.blogAPI.exception.NotAllowedException;
+import com.esiea.blogAPI.exception.NotFoundException;
+import com.esiea.blogAPI.model.Article;
+import com.esiea.blogAPI.model.Category;
+import com.esiea.blogAPI.repository.CategoryRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private Article article1 = mock(Article.class);
+    @Mock
+    private Article article2 = mock(Article.class);
+    @Mock
+    private Article article3 = mock(Article.class);
+    @Mock
+    private Category category1 = mock(Category.class);
+    @Mock
+    private Category category2 = mock(Category.class);
+    @Mock
+    private Category category3 = mock(Category.class);
+    @Mock
+    private CategoryRepository categoryRepository = mock(CategoryRepository.class);
+    @InjectMocks
+    private CategoryService categoryService;
+    private List<Article> articles1;
+    private List<Article> articles2;
+    @BeforeEach
+    void setUp() throws Exception {
+        articles1 = new ArrayList<>();
+        articles1.add(article1);
+        articles1.add(article2);
+
+        articles2 = new ArrayList<>();
+        articles2.add(article2);
+        articles2.add(article3);
+    }
+    @Test
+    void getCategories() {
+        List<Category> categories1 = new ArrayList<>();
+        categories1.add(category1);
+        categories1.add(category2);
+        when(categoryRepository.findAll()).thenReturn(categories1);
+        when(category1.toString()).thenReturn("category1");
+        when(category2.toString()).thenReturn("category2");
+        Iterable<Category> result = categoryService.getCategories();
+        Iterator<Category> resultIterator = result.iterator();
+        Assertions.assertEquals( "category1" ,resultIterator.next().toString());
+        Assertions.assertEquals( "category2" ,resultIterator.next().toString());
+    }
+
+    @Test
+    void getCategoryGood() throws NotFoundException {
+        Long id = Long.valueOf(1);
+        List<Category> categories1 = new ArrayList<>();
+        when(categoryRepository.findById(id)).thenReturn(Optional.of(category1));
+        when(category1.toString()).thenReturn("category1");
+        Category result = categoryService.getCategory(id);
+        Assertions.assertEquals( "category1" ,result.toString());
+    }
+    @Test
+    void getCategoryWrong(){
+        Long id = Long.valueOf(1);
+        when(categoryRepository.findById(id)).thenReturn(Optional.empty());
+        Assertions.assertThrowsExactly(NotFoundException.class, () ->{categoryService.getCategory(id);});
+    }
+
+    @Test
+    void createCategoryIfNotExistSaveCategory() throws NotAllowedException, NotFoundException {
+        when(category1.getId()).thenReturn(null);
+        when(categoryRepository.save(category1)).thenReturn(category2);
+        when(category2.toString()).thenReturn("category2");
+        Category result = categoryService.CreateCategoryIfNotExist(category1);
+        Assertions.assertEquals("category2", result.toString());
+    }
+
+    @Test
+    void createCategoryIfNotExistGetCategory() throws NotAllowedException, NotFoundException {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category2.toString()).thenReturn("category2");
+        when(category2.equalsOrNull(category1)).thenReturn(true);
+        Category result = categoryService.CreateCategoryIfNotExist(category1);
+        assertEquals("category2", result.toString());
+    }
+
+    @Test
+    void createCategoryIfNotExistGetCategoryWrong() throws NotAllowedException {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category2.equalsOrNull(category1)).thenReturn(false);
+        assertThrowsExactly(NotFoundException.class,()  ->{categoryService.CreateCategoryIfNotExist(category1);});
+    }
+
+    @Test
+    void saveGood() throws NotAllowedException {
+        when(categoryRepository.save(category1)).thenReturn(category2);
+        // Le save rajoute un id, donc la catégorie retournée n'est pas la même que celle en entrée
+        when(category2.toString()).thenReturn("category2");
+        when(category1.getId()).thenReturn(null);
+        Category result = categoryService.save(category1);
+        Assertions.assertEquals("category2", result.toString());
+    }
+
+    @Test
+    void saveWrong(){
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotAllowedException.class, () ->{categoryService.save(category1);});
+    }
+
+    @Test
+    void replaceGood() throws NotAllowedException, NotFoundException {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(categoryRepository.save(category1)).thenReturn(category3);
+        when(category3.toString()).thenReturn("category3");
+        Category result = categoryService.replace(category1);
+        Assertions.assertEquals("category3", result.toString());
+    }
+
+    @Test
+    void replaceNotFoundException() throws NotAllowedException, NotFoundException {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.empty());
+        Assertions.assertThrowsExactly(NotFoundException.class, ()->{ categoryService.replace(category1);});
+    }
+
+    @Test
+    void testPatchWithoutChangeByNull() throws NotFoundException, CantModifyItem {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category1.getCategoryName()).thenReturn(null);
+        //when(category2.getCategoryName()).thenReturn("categoryName");
+        when(category1.getArticles()).thenReturn(null);
+        //when(category2.getArticles()).thenReturn(articles1);
+        when(categoryRepository.save(category2)).thenReturn(category2);
+        when(category2.toString()).thenReturn("category2");
+
+        Category result = categoryService.patch(category1);
+        Assertions.assertEquals(category2.toString(), result.toString());
+    }
+
+    @Test
+    void testPatchWithoutChangeBySameCategoryName() throws NotFoundException, CantModifyItem {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category1.getCategoryName()).thenReturn("categoryName");
+        when(category2.getCategoryName()).thenReturn("categoryName");
+        when(category1.getArticles()).thenReturn(null);
+        //when(category2.getArticles()).thenReturn(articles1);
+        when(categoryRepository.save(category2)).thenReturn(category2);
+        when(category2.toString()).thenReturn("category2");
+
+        Category result = categoryService.patch(category1);
+        Assertions.assertEquals(category2.toString(), result.toString());
+    }
+
+    @Test
+    void testPatchWithCategoryNameChange() throws NotFoundException, CantModifyItem {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category1.getCategoryName()).thenReturn("CategoryName1");
+        when(category2.getCategoryName()).thenReturn("CategoryName2");
+        doNothing().when(category2).setCategoryName("CategoryName1");
+        when(category1.getArticles()).thenReturn(null);
+        //when(category2.getArticles()).thenReturn(articles1);
+        when(categoryRepository.save(category2)).thenReturn(category2);
+        when(category2.toString()).thenReturn("category2");
+
+        Category result = categoryService.patch(category1);
+        Assertions.assertEquals(category2.toString(), result.toString());
+    }
+
+    @Test
+    void testPatchWithoutChangeBySameGetArticles() throws NotFoundException, CantModifyItem {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category1.getCategoryName()).thenReturn(null);
+        //when(category2.getCategoryName()).thenReturn("categoryName");
+        when(category1.getArticles()).thenReturn(articles1);
+        when(category2.getArticles()).thenReturn(articles1);
+        when(categoryRepository.save(category2)).thenReturn(category2);
+        when(category2.toString()).thenReturn("category2");
+
+        Category result = categoryService.patch(category1);
+        Assertions.assertEquals(category2.toString(), result.toString());
+    }
+
+    @Test
+    void testPatchWithChangeGetArticles() throws NotFoundException, CantModifyItem {
+        when(category1.getId()).thenReturn(Long.valueOf(1));
+        when(categoryRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(category2));
+        when(category1.getCategoryName()).thenReturn(null);
+        //when(category2.getCategoryName()).thenReturn("categoryName");
+        when(category1.getArticles()).thenReturn(articles1);
+        when(category2.getArticles()).thenReturn(articles2);
+
+        Assertions.assertThrowsExactly(CantModifyItem.class, ()->{categoryService.patch(category1);}); ;
+    }
+
+    @Test
+    void delete() throws NotFoundException {
+        doNothing().when(categoryRepository).deleteById(Long.valueOf(1));
+        categoryService.delete(Long.valueOf(1));
+    }
+
+    @Test
+    void deleteWrong() {
+        doThrow(EmptyResultDataAccessException.class).when(categoryRepository).deleteById(Long.valueOf(1));
+        Assertions.assertThrowsExactly(NotFoundException.class, () ->{categoryService.delete(Long.valueOf(1));});
+    }
+}


### PR DESCRIPTION
Service article :
#13 Ajouter un article
#9 Récupérer les articles
#11 Récupérer un article avec l'ID
#32 Supprimer un article
#33 Remplacer la définition d'un article par un autre
#34 patcher un article

Service auteur :
#20 ajouter un auteur
#16 Récupérer un auteur
#21 Suppression d'un auteur
#22 Remplacement d'un auteur
#23 Modifier un auteur 

Service catégorie :
#12 Ajouter une catégorie 
#10 Récupérer les articles appartenant à une catégorie
#28 Récupérer l'ensemble des catégories 